### PR TITLE
chore: add weekly dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/docker/dev"
+      - "/docker/prod"
+      - "/docker/prod/pgbouncer"
+      - "/docker/prod/timescaledb"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "docker"
+      include: "scope"
+    groups:
+      docker-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/README.md
+++ b/README.md
@@ -589,6 +589,16 @@ uv run ruff check .
 uv run mypy apps/
 ```
 
+### Dependabot
+
+Dependency updates are automated via Dependabot (`.github/dependabot.yml`). Three ecosystems are scanned **weekly on Mondays**:
+
+- **`uv`** — Python dependencies at the repository root (`pyproject.toml` + `uv.lock`).
+- **`github-actions`** — workflow files under `.github/workflows/`.
+- **`docker`** — all Dockerfiles under `docker/dev`, `docker/prod`, `docker/prod/pgbouncer`, and `docker/prod/timescaledb`.
+
+Minor and patch bumps are grouped into a single PR per ecosystem to reduce review churn; major bumps land as individual PRs. Generated PRs carry a `dependencies` label plus an ecosystem tag (`python`, `github-actions`, or `docker`) and conventional commit prefixes (`deps`, `ci`, or `docker`) for easy filtering.
+
 ### Code Quality
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with three ecosystems scheduled for **weekly Monday** runs.
- Covers Python deps (`uv` ecosystem → `pyproject.toml` + `uv.lock`), GitHub Actions workflows, and all four Dockerfiles under `docker/` (dev, prod, pgbouncer, timescaledb).
- Groups minor + patch bumps per ecosystem to cut PR noise; majors stay as individual PRs.
- Labels PRs (`dependencies` + ecosystem tag) and sets commit prefixes (`deps` / `ci` / `docker`) for easy filtering.
- Documents the automation in `README.md` under the Pull Request CI section so contributors know the cadence and grouping rules without having to read the config.

## Notes
- Uses Dependabot's native `uv` ecosystem (not generic `pip`) so `uv.lock` is respected.
- Uses the `directories:` plural form to cover all four Dockerfile paths under a single `docker` update block.
- ~~Per `CLAUDE.md` §3.1, Dependabot PRs fall under the Scheduled Agent SDD exemption.~~ Retracted — §3.1 exempts PRs opened *by* the scheduled agents, not the act of configuring them. See https://github.com/gidorah/peebot/pull/128#discussion_r3079891888. Proceeding without implementation-folder docs by the author's explicit decision; README coverage is the only doc update.

## Test plan
- [ ] Merge and wait for first Monday run — verify Dependabot opens grouped PRs for each ecosystem.
- [ ] Confirm labels and commit prefixes land correctly on generated PRs.
- [ ] Spot-check that `uv.lock` gets updated alongside `pyproject.toml` on a Python bump.