### PR TITLE
🐛 fix: filter Celery consumer log messages in Sentry before_send

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -263,10 +263,14 @@ def _sentry_before_send(event: Event, _hint: dict[str, Any]) -> Event | None:
       deploys prevents Beat from scheduling tasks. Beat retries
       automatically.
     - kombu.exceptions.OperationalError: transient DNS/Redis blips during
-      container restarts. Kombu reconnects automatically. CAUTION: this
-      also suppresses prolonged Redis outages from this logger. Genuine
-      outages surface via task-level OperationalError (autoretry exhaustion)
-      and /readyz health check failures.
+      container restarts. Kombu reconnects automatically.
+    - celery.worker.consumer.consumer log messages: Celery's consumer
+      logs connection failures at ERROR level during reconnect attempts.
+      These are log-message events (no exception attached), so we match
+      on logger name instead of exception type. CAUTION: this also
+      suppresses prolonged Redis outages from this logger. Genuine
+      outages surface via task-level OperationalError (autoretry
+      exhaustion) and /readyz health check failures.
     """
     request = event.get("request")
     if isinstance(request, dict):
@@ -276,13 +280,18 @@ def _sentry_before_send(event: Event, _hint: dict[str, Any]) -> Event | None:
         ):
             return None
 
+    logger_name = event.get("logger", "")
+
+    # PEEBOT-D: Celery consumer log messages (log-message events, no exception).
+    if logger_name == "celery.worker.consumer.consumer":
+        return None
+
     exception = event.get("exception", {}).get("values", [])
     if not exception:
         return event
 
     exc_type = exception[0].get("type", "")
     exc_module = exception[0].get("module", "")
-    logger_name = event.get("logger", "")
 
     if exc_type == "SchedulingError" and logger_name == "celery.beat":
         return None

--- a/config/tests/test_sentry_filter.py
+++ b/config/tests/test_sentry_filter.py
@@ -90,8 +90,37 @@ class TestSchedulingErrorFilter:
         assert _sentry_before_send(event, {}) is event
 
 
+class TestCeleryConsumerLogFilter:
+    """Filter Celery consumer log messages (PEEBOT-D, no exception attached)."""
+
+    def test_celery_consumer_log_is_filtered(self) -> None:
+        """Log messages from celery.worker.consumer.consumer are dropped."""
+        event = cast(Event, {"logger": "celery.worker.consumer.consumer"})
+        assert _sentry_before_send(event, {}) is None
+
+    def test_celery_consumer_log_with_logentry_is_filtered(self) -> None:
+        """Log messages with logentry from celery.worker.consumer.consumer are dropped."""
+        event = cast(
+            Event,
+            {
+                "logger": "celery.worker.consumer.consumer",
+                "logentry": {
+                    "message": "consumer: Cannot connect to %s: %s.\n%s\n",
+                    "formatted": "consumer: Cannot connect to redis://redis:6379/0: ...",
+                    "params": ["redis://redis:6379/0", "Error", "Trying again..."],
+                },
+            },
+        )
+        assert _sentry_before_send(event, {}) is None
+
+    def test_other_celery_logger_is_not_filtered(self) -> None:
+        """Log messages from other celery loggers pass through."""
+        event = cast(Event, {"logger": "celery.worker"})
+        assert _sentry_before_send(event, {}) is event
+
+
 class TestKombuOperationalErrorFilter:
-    """Filter OperationalError from kombu.exceptions (PEEBOT-D)."""
+    """Filter OperationalError from kombu.exceptions."""
 
     def test_kombu_operational_error_is_filtered(self) -> None:
         """OperationalError from kombu.exceptions is dropped."""


### PR DESCRIPTION
## Summary

- Fix `_sentry_before_send` to also filter PEEBOT-D events, which are **log messages** (not exception events) from `celery.worker.consumer.consumer`
- Add logger-name check before the exception check so log-message events without an `exception` field are caught
- Add 3 new unit tests covering the log-message filter path

## Root Cause

PEEBOT-D events are ERROR-level log messages emitted by Celery's consumer during Redis reconnect attempts. Unlike PEEBOT-10/11 (which are `SchedulingError` exception events), PEEBOT-D events have **no `exception` field** — they're pure log messages captured by Sentry's LoggingIntegration.

The previous filter checked `exception[0].type` first. When there was no exception, it hit `if not exception: return event` and passed through, letting all PEEBOT-D events reach Sentry.

## Fix

Move the `logger_name` extraction before the exception check, and add a direct match on `celery.worker.consumer.consumer`. This catches the log-message events regardless of whether they have an exception attached.

Closes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error tracking by filtering out routine connection-failure messages from background task processing, reducing noise in error monitoring.

* **Tests**
  * Added test coverage for the error tracking filter to ensure proper exclusion of specific background task logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->