### PR TITLE
🐛 fix: filter ingestion flush_buffer OperationalError in Sentry (PEEBOT-E)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -290,6 +290,17 @@ def _sentry_before_send(event: Event, _hint: dict[str, Any]) -> Event | None:
     if exc_type == "OperationalError" and exc_module == "kombu.exceptions":
         return None
 
+    # PEEBOT-E: Ingestion flush_buffer handles Postgres disconnects by closing
+    # the stale connection and retrying on the next cycle. The error is caught
+    # and logged with exc_info=True, which Sentry's LoggingIntegration captures
+    # as an exception event despite the WARNING level.
+    if (
+        exc_type == "OperationalError"
+        and logger_name
+        == "apps.telemetry_ingestion.management.commands.run_lightstreamer"
+    ):
+        return None
+
     return event
 
 

--- a/config/tests/test_sentry_filter.py
+++ b/config/tests/test_sentry_filter.py
@@ -129,6 +129,28 @@ class TestKombuOperationalErrorFilter:
         assert _sentry_before_send(event, {}) is event
 
 
+class TestIngestionFlushErrorFilter:
+    """Filter ingestion flush_buffer OperationalError (PEEBOT-E)."""
+
+    def test_ingestion_operational_error_is_filtered(self) -> None:
+        """OperationalError from ingestion flush_buffer is dropped."""
+        event = _make_event(
+            exception_type="OperationalError",
+            exception_module="django.db.utils",
+            logger="apps.telemetry_ingestion.management.commands.run_lightstreamer",
+        )
+        assert _sentry_before_send(event, {}) is None
+
+    def test_other_db_operational_error_is_not_filtered(self) -> None:
+        """OperationalError from other loggers passes through."""
+        event = _make_event(
+            exception_type="OperationalError",
+            exception_module="django.db.utils",
+            logger="django.db.backends",
+        )
+        assert _sentry_before_send(event, {}) is event
+
+
 class TestEdgeCases:
     """Boundary conditions for the filter."""
 


### PR DESCRIPTION
## Summary

- Add `_sentry_before_send` filter for `OperationalError` from the ingestion command logger
- The `flush_buffer` method already handles Postgres disconnects gracefully (closes stale connection, retries next cycle), so these events are noise

## Root Cause

PEEBOT-E events are `OperationalError` exceptions from `flush_buffer` in `run_lightstreamer.py`. The code catches this exception and logs at WARNING level with `exc_info=True`. Despite the WARNING level, Sentry's LoggingIntegration captures the `exc_info` as an exception event (mechanism: `{'type': 'logging', 'handled': True}`).

The error handling is already correct — the stale connection is closed and the next flush cycle creates a fresh one. The Sentry event is noise from a handled, self-recovering error.

## Fix

Filter `OperationalError` events from `apps.telemetry_ingestion.management.commands.run_lightstreamer` logger in `_sentry_before_send`. This is safe because:
- The error is caught and handled (connection closed, retry on next cycle)
- The ingestion loop continues running
- Other `OperationalError` events from different loggers are NOT filtered

Closes #127