### PR TITLE
🐛 fix: add per-task time limits to run_peebot_processor

### DIFF
--- a/apps/event_processors/tasks.py
+++ b/apps/event_processors/tasks.py
@@ -37,6 +37,8 @@ logger = structlog.get_logger(__name__)
 
 @shared_task(
     bind=True,
+    soft_time_limit=120,
+    time_limit=180,
     autoretry_for=(OperationalError,),
     retry_backoff=True,
     retry_backoff_max=60,


### PR DESCRIPTION
Closes #148

## Root cause

`run_peebot_processor` inherited the global 25-minute `CELERY_TASK_SOFT_TIME_LIMIT`. When the task hangs (DB lock during TimescaleDB compression, network stall to OpenRouter/Bluesky), it occupies a Celery worker for up to 25 minutes — far too long for a task that runs every 30 seconds and normally completes in <25s.

## Fix

Added per-task limits:
- `soft_time_limit=120` (2 minutes — generous for normal operation)
- `time_limit=180` (3 minutes hard kill)

The existing `except Exception` handler already catches `SoftTimeLimitExceeded` gracefully (logs error + updates state). The next Beat run (30s later) starts a fresh attempt.

Sentry PEEBOT-2: 20 events. Seer unavailable.

Auto-resolved by the peebot daily maintenance agent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkUgNUbZ4CtsKJhB813f2v)_