### PR TITLE
🐛 fix: replace async_to_sync with asyncio.run to fix thread exhaustion

### DIFF
--- a/apps/event_processors/tasks.py
+++ b/apps/event_processors/tasks.py
@@ -7,11 +7,12 @@ data, runs analysis, and triggers actions on event detection.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from typing import Any
 
 import structlog
-from asgiref.sync import async_to_sync, sync_to_async
+from asgiref.sync import sync_to_async
 from celery import shared_task
 from django.conf import settings
 from django.db import OperationalError, close_old_connections
@@ -58,7 +59,7 @@ def run_peebot_processor(self: Any) -> dict[str, Any]:
     Returns:
         Dict with execution summary including event detection status
     """
-    return async_to_sync(_run_peebot_processor_async)()
+    return asyncio.run(_run_peebot_processor_async())
 
 
 async def _run_peebot_processor_async() -> dict[str, Any]:


### PR DESCRIPTION
Closes #150

## Root cause

`async_to_sync(_run_peebot_processor_async)()` at `tasks.py:61` creates an extra OS thread via `ThreadPoolExecutor` for every task invocation. The `openai` SDK then calls `asyncio.to_thread()` inside the async path, attempting to spawn yet more threads. With `--concurrency=2` workers firing every 30 s, threads accumulate and hit the OS thread-table limit:

```
RuntimeError: can't start new thread
  apps/event_processors/tasks.py:61 → async_to_sync()
  concurrent/futures/thread.py → t.start()          # PEEBOT-13 (4045 events, escalating)

  openai/_base_client.py → asyncio.to_thread()
  concurrent/futures/thread.py → t.start()          # PEEBOT-12 (147 events)
  # → joke_generation_failed_all_retries             # PEEBOT-14 (49 events)
```

PR #149 (per-task time limits, closes #148) is a useful complementary mitigation but does not remove the extra thread created by `async_to_sync` itself.

## Fix

Replace `async_to_sync(_run_peebot_processor_async)()` with `asyncio.run(_run_peebot_processor_async())`.

`asyncio.run()` runs the coroutine **in the current Celery worker thread** — no extra thread is created. When the loop closes, its `ThreadPoolExecutor` is shut down, so threads from `asyncio.to_thread` (openai SDK) are reaped after each task instead of accumulating.

The `sync_to_async(close_old_connections, thread_sensitive=True)()` call in the `OperationalError` handler is unaffected: `thread_sensitive=True` always dispatches to asgiref's shared single-thread executor, independent of whether the outer loop was started by `async_to_sync` or `asyncio.run`.

## Sentry references
- PEEBOT-13: https://onur-akyuz.sentry.io/issues/PEEBOT-13 (4045 events, escalating)
- PEEBOT-12: https://onur-akyuz.sentry.io/issues/PEEBOT-12 (147 events)
- PEEBOT-14: https://onur-akyuz.sentry.io/issues/PEEBOT-14 (49 events)

Seer analysis: unavailable (no budget).

Auto-resolved by the peebot daily maintenance agent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXogViTb5SigtS2U5JCXek)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved async event processor execution for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->