### PR TITLE
🐛 fix: bump celery worker healthcheck timeout to prevent false unhealthy state

### DIFF
--- a/docker/prod/docker-compose.yml
+++ b/docker/prod/docker-compose.yml
@@ -291,7 +291,7 @@ services:
     stop_grace_period: 60s
 
     healthcheck:
-      test: ["CMD-SHELL", "celery -A config inspect ping --timeout=20 || exit 1"]
+      test: ["CMD-SHELL", "celery -A config inspect ping --timeout=20 --destination=worker@$$(hostname) || exit 1"]
       interval: 30s
       timeout: 30s
       retries: 3

--- a/docker/prod/docker-compose.yml
+++ b/docker/prod/docker-compose.yml
@@ -291,9 +291,9 @@ services:
     stop_grace_period: 60s
 
     healthcheck:
-      test: ["CMD-SHELL", "celery -A config inspect ping --timeout=10 || exit 1"]
+      test: ["CMD-SHELL", "celery -A config inspect ping --timeout=20 || exit 1"]
       interval: 30s
-      timeout: 15s
+      timeout: 30s
       retries: 3
       start_period: 60s
 


### PR DESCRIPTION
## Summary

- Bump Docker healthcheck `timeout: 15s → 30s` and Celery `--timeout=10 → 20` for the production worker in `docker/prod/docker-compose.yml`.
- Prevents the worker container from being misreported as `unhealthy` while Celery is, in fact, alive and processing tasks normally.
- No interval/retries/start_period change. Single-file, single-concern infra hotfix.

## Why

Production validation of the #150/#151 fix surfaced a separate, pre-existing issue: the worker container was sitting at `Up 34 minutes (unhealthy)` with `Health.FailingStreak: 45`, even though `docker inspect` showed the actual probe output as:

```
Health check exceeded timeout (15s): -> worker@874c18986ce6: OK
        pong
```

Celery is replying `pong` correctly — but the full `celery -A config inspect ping` invocation regularly exceeds the 15s Docker-level timeout. Cause: the CLI has to cold-import Django + Celery + the `config` app, then round-trip a control message through Redis. Under the worker's 1G memory limit and concurrent task load, that easily takes >15s.

Result: Coolify saw a perpetually unhealthy container and was at risk of triggering an unnecessary restart loop.

## What changed

```diff
     healthcheck:
-      test: ["CMD-SHELL", "celery -A config inspect ping --timeout=10 || exit 1"]
+      test: ["CMD-SHELL", "celery -A config inspect ping --timeout=20 || exit 1"]
       interval: 30s
-      timeout: 15s
+      timeout: 30s
       retries: 3
       start_period: 60s
```

## Validation context (separate from this PR)

While verifying the deployed PR #151 fix for issue #150, I confirmed via SSH to the production VPS:

- Worker image tag `:42096368bd0a9d32016ff5238a034370c9809da6` matches the merged commit `4209636` ✓
- Logs from 08:35–09:10 UTC: 70+ task invocations, all `succeeded in 0.7-5.0s`, **zero** `RuntimeError: can't start new thread`
- Sentry `PEEBOT-13/12/14` events since deploy: **0** (down from 4241 pre-fix)

So #150 is empirically resolved. This PR addresses the orthogonal healthcheck-config issue discovered during that validation.

## Test plan

- [ ] Coolify rebuilds and redeploys the worker on merge.
- [ ] After ~2 min (post `start_period`), `docker inspect <worker> --format '{{.State.Health.Status}}'` returns `healthy`.
- [ ] `Health.FailingStreak` resets to `0` and stays there.
- [ ] No regression: `RuntimeError: can't start new thread` does not return in Sentry over the next 24h.
- [ ] Worker continues processing `run_peebot_processor` every 30s with sub-5s duration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved worker service reliability by extending health check timeouts, reducing false failure alerts and enhancing system stability during high-load periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->