### PR TITLE
🐛 fix: replace asyncio.run with async_to_sync to reduce thread exhaustion (Sentry PEEBOT-13)

### DIFF
--- a/apps/event_processors/tasks.py
+++ b/apps/event_processors/tasks.py
@@ -168,6 +168,9 @@ async def _run_peebot_processor_async() -> dict[str, Any]:
     except OperationalError:
         # Close broken/stale connections in the same thread/Executor that
         # Django's async ORM uses, so the Celery retry gets a fresh one.
+        # thread_sensitive=False: Celery is not an ASGI context, so True would
+        # cause asgiref to spawn a dedicated _AsyncThread per call instead of
+        # using the shared executor where the DB connection actually lives.
         await sync_to_async(close_old_connections, thread_sensitive=False)()
         # Log at warning – this is a transient error that Celery will retry.
         # Logging at error level would generate a Sentry event for every

--- a/apps/event_processors/tasks.py
+++ b/apps/event_processors/tasks.py
@@ -7,12 +7,11 @@ data, runs analysis, and triggers actions on event detection.
 
 from __future__ import annotations
 
-import asyncio
 from datetime import timedelta
 from typing import Any
 
 import structlog
-from asgiref.sync import sync_to_async
+from asgiref.sync import async_to_sync, sync_to_async
 from celery import shared_task
 from django.conf import settings
 from django.db import OperationalError, close_old_connections
@@ -59,7 +58,7 @@ def run_peebot_processor(self: Any) -> dict[str, Any]:
     Returns:
         Dict with execution summary including event detection status
     """
-    return asyncio.run(_run_peebot_processor_async())
+    return async_to_sync(_run_peebot_processor_async)()
 
 
 async def _run_peebot_processor_async() -> dict[str, Any]:
@@ -169,7 +168,7 @@ async def _run_peebot_processor_async() -> dict[str, Any]:
     except OperationalError:
         # Close broken/stale connections in the same thread/Executor that
         # Django's async ORM uses, so the Celery retry gets a fresh one.
-        await sync_to_async(close_old_connections, thread_sensitive=True)()
+        await sync_to_async(close_old_connections, thread_sensitive=False)()
         # Log at warning – this is a transient error that Celery will retry.
         # Logging at error level would generate a Sentry event for every
         # routine connection hiccup, creating noise before retries even run.


### PR DESCRIPTION
Closes #153

## Root cause summary

`run_peebot_processor` called `asyncio.run(_run_peebot_processor_async())` directly. In a Celery (non-ASGI) context, every invocation creates a **new event loop with its own `ThreadPoolExecutor`**. When Beat fires the task every 30 s and previous instances stall (no per-task time limit), concurrent workers each hold an open event loop + thread pool. Once combined thread count hits the OS limit, every subsequent `asyncio.run()` raises `RuntimeError: can't start new thread` — explaining PEEBOT-13's 4,045-event spike.

The `OperationalError` retry path also called `sync_to_async(close_old_connections, thread_sensitive=True)`. In a non-ASGI context, `thread_sensitive=True` attempts to dispatch to an ASGI main thread that doesn't exist, causing asgiref to spawn a dedicated `_AsyncThread` on every retry — adding per-retry thread overhead.

## Changes

| File | Change |
|------|--------|
| `apps/event_processors/tasks.py` | Replace `asyncio.run(coro())` with `async_to_sync(coro)()` — the Django-idiomatic pattern that pairs correctly with `sync_to_async` and manages the event loop lifecycle within asgiref's thread model |
| `apps/event_processors/tasks.py` | `sync_to_async(close_old_connections, thread_sensitive=False)` — runs in the thread-pool executor (where the DB connection lives) instead of spinning up a new dedicated thread |
| `apps/event_processors/tasks.py` | Remove unused `import asyncio` |

## Relationship to PR #149

PR #149 adds `soft_time_limit=120` / `time_limit=180` to the `@shared_task` decorator — that is the **primary fix** (bounds maximum concurrent overlap to ~6 tasks). This PR is **complementary**: it reduces per-invocation thread overhead so the remaining concurrent tasks stay within OS limits. Both PRs should land; neither conflicts with the other (they touch different parts of the decorator vs. the function body).

Auto-resolved by the peebot daily maintenance agent. Seer unavailable (no Autofix budget).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fpmmqr4dT2rw1ZDmGHPad3)_